### PR TITLE
Update the bot dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,26 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wiggly-games/data-structures": "^1.0.2",
-        "@wiggly-games/files": "^1.0.5",
+        "@wiggly-games/data-structures": "^2.0.3",
+        "@wiggly-games/files": "^1.1.3",
         "@wiggly-games/logs": "^1.0.1",
-        "@wiggly-games/markov-chains": "^3.1.2",
+        "@wiggly-games/markov-chains": "^5.0.0",
+        "@wiggly-games/node-readline": "^1.0.1",
         "better-sqlite3": "^11.0.0",
-        "discord-api-types": "^0.37.85",
-        "discord.js": "^14.15.2",
+        "discord-api-types": "^0.37.90",
+        "discord.js": "^14.15.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "knex": "^3.1.0"
       },
       "devDependencies": {
-        "@types/node": "^20.12.12"
+        "@types/node": "^20.14.8"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.1.tgz",
-      "integrity": "sha512-GkF+HM01FHy+NSoTaUPR8z44otfQgJ1AIsRxclYGUZDyUbdZEFyD/5QVv2Y1Flx6M+B0bQLzg2M9CJv5lGTqpA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2.tgz",
+      "integrity": "sha512-6wvG3QaCjtMu0xnle4SoOIeFB4y6fKMN6WZfy3BMKJdQQtPLik8KGzDwBVL/+wTtcE/ZlFjgEk74GublyEVZ7g==",
       "dependencies": {
         "@discordjs/formatters": "^0.4.0",
         "@discordjs/util": "^1.1.0",
@@ -126,9 +127,9 @@
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0.tgz",
-      "integrity": "sha512-O97DIeSvfNTn5wz5vaER6ciyUsr7nOqSEtsLoMhhIgeFkhnxLRqSr00/Fpq2/ppLgjDGLbQCDzIK7ilGoB/M7A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
       "dependencies": {
         "@discordjs/collection": "^2.1.0",
         "@discordjs/rest": "^2.3.0",
@@ -266,9 +267,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -282,24 +283,28 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
-      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.3.0.tgz",
+      "integrity": "sha512-pmkbRGAqTM3N7R4KCObOAqqoZzeURR6oC11amaXmY4ZLShu4MdLymm1/F0fZssYKAsSE79TibRbdXwfvYMIt0Q==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@wiggly-games/data-structures": {
-      "version": "1.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/1.0.2/eac83b3847d125124b2ecb058f495f95b56529cc",
-      "integrity": "sha512-Gvd3PSo35Cn2en6SDtcAORN26J9+02GLl/aIiqavkEfGghRggwXyHiLdVZxyU4ujjkm6EESh9/0luA+wNofxow==",
-      "license": "ISC"
+      "version": "2.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/2.0.3/460851249b369cdb65e3e0ac55613ba2996c82a2",
+      "integrity": "sha512-gcgobRIh8g5iSZB5sIVyLMqN24U3sgNBkaHrRPGAqnrEEwLpfILvdr/yxkgJmzyPIP553Q0p1hhnGBtKmPdL5w==",
+      "license": "ISC",
+      "dependencies": {
+        "@wiggly-games/files": "^1.1.3",
+        "@wiggly-games/node-readline": "^1.0.1"
+      }
     },
     "node_modules/@wiggly-games/files": {
-      "version": "1.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.0/980fe16b7d5b72af7f0754496fe92ec4216858da",
-      "integrity": "sha512-+AhroW0oV98vV4XLA+/U1FEAvueJ6ZoIVwQibKoG08oG4XmRNgyTwmWQePoR9zbQ9UTli3bkaxnp1ubCJVJ3gw==",
+      "version": "1.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.3/a4fdb1e872b660237a0bedff63c37824f132343c",
+      "integrity": "sha512-VuRJU7jX4E89FIK1ohOrkrzJCjizChyzWJn/EGej2DmcgT0REQvVUXCuGm3cQV7ydSV9KJQsLQBNzwz34n6hQg==",
       "license": "ISC"
     },
     "node_modules/@wiggly-games/logs": {
@@ -309,9 +314,9 @@
       "license": "ISC"
     },
     "node_modules/@wiggly-games/markov-chains": {
-      "version": "3.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/markov-chains/3.1.2/c0e805e1056a83e60d8053b4e9ffc2825020afa4",
-      "integrity": "sha512-QARqHASAb8ioCeQy2Xt4vAn1fUriE4IhVqil/ZOMOLhrz6ed5lAR/TwUpC7+WaXpFBADGpxS1T+GK5LyNT7yfg==",
+      "version": "5.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/markov-chains/5.0.0/b719e78c41c7e38e7e149b843569af220230207b",
+      "integrity": "sha512-+oiBxEaRMbSKISuz26zupC1HIUYvJzWF//tZ6jsoR9ZlwHzw7lUb5dMovm6+ITeOrT+9q/bavgFzveuFO3uSTw==",
       "license": "ISC",
       "dependencies": {
         "@wiggly-games/data-structures": "^2.0.0",
@@ -319,10 +324,11 @@
         "msgpackr": "^1.10.2"
       }
     },
-    "node_modules/@wiggly-games/markov-chains/node_modules/@wiggly-games/data-structures": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/2.0.0/4137d07440f6a4c54b9116bd328e225fd9105a27",
-      "integrity": "sha512-Sa9VpaFNDNO7xRsBMSnMVID4awLWTKTmNnBDzXNn9Uv42hKkDmaNDuivErvE69ObZW9pVSh/Pvv48soLm7ZN/Q==",
+    "node_modules/@wiggly-games/node-readline": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/node-readline/1.0.1/62837275964b51d28a85001eefcecd22e782e80a",
+      "integrity": "sha512-Vd7KWU0/SVwrGYDwEEjx7XU8mIRwqRO6yHBKmz5MLtrbjCj4FB9nDefbdJD1nAmZjORqrixGOhc8SijhRyNzJQ==",
+      "hasInstallScript": true,
       "license": "ISC"
     },
     "node_modules/accepts": {
@@ -583,21 +589,21 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.85",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.85.tgz",
-      "integrity": "sha512-T75aB9JEw9X0rlMChEMHbr9JlXMqdmdKiZVjBeKs91cJo28IuAIldj+VZoC+I+Q9gCaRjHlwRkcksy2XZY6c3A=="
+      "version": "0.37.90",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+      "integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
     },
     "node_modules/discord.js": {
-      "version": "14.15.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.2.tgz",
-      "integrity": "sha512-wGD37YCaTUNprtpqMIRuNiswwsvSWXrHykBSm2SAosoTYut0VUDj9yo9t4iLtMKvuhI49zYkvKc2TNdzdvpJhg==",
+      "version": "14.15.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3.tgz",
+      "integrity": "sha512-/UJDQO10VuU6wQPglA4kz2bw2ngeeSbogiIPx/TsnctfzV/tNf+q+i1HlgtX1OGpeOBpJH9erZQNO5oRM2uAtQ==",
       "dependencies": {
-        "@discordjs/builders": "^1.8.1",
+        "@discordjs/builders": "^1.8.2",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.4.0",
         "@discordjs/rest": "^2.3.0",
         "@discordjs/util": "^1.1.0",
-        "@discordjs/ws": "^1.1.0",
+        "@discordjs/ws": "^1.1.1",
         "@sapphire/snowflake": "3.5.3",
         "discord-api-types": "0.37.83",
         "fast-deep-equal": "3.1.3",
@@ -1723,9 +1729,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1745,9 +1751,9 @@
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.1.tgz",
-      "integrity": "sha512-GkF+HM01FHy+NSoTaUPR8z44otfQgJ1AIsRxclYGUZDyUbdZEFyD/5QVv2Y1Flx6M+B0bQLzg2M9CJv5lGTqpA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2.tgz",
+      "integrity": "sha512-6wvG3QaCjtMu0xnle4SoOIeFB4y6fKMN6WZfy3BMKJdQQtPLik8KGzDwBVL/+wTtcE/ZlFjgEk74GublyEVZ7g==",
       "requires": {
         "@discordjs/formatters": "^0.4.0",
         "@discordjs/util": "^1.1.0",
@@ -1819,9 +1825,9 @@
       "integrity": "sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg=="
     },
     "@discordjs/ws": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0.tgz",
-      "integrity": "sha512-O97DIeSvfNTn5wz5vaER6ciyUsr7nOqSEtsLoMhhIgeFkhnxLRqSr00/Fpq2/ppLgjDGLbQCDzIK7ilGoB/M7A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
       "requires": {
         "@discordjs/collection": "^2.1.0",
         "@discordjs/rest": "^2.3.0",
@@ -1902,9 +1908,9 @@
       "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
     },
     "@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -1918,19 +1924,23 @@
       }
     },
     "@vladfrangu/async_event_emitter": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
-      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.3.0.tgz",
+      "integrity": "sha512-pmkbRGAqTM3N7R4KCObOAqqoZzeURR6oC11amaXmY4ZLShu4MdLymm1/F0fZssYKAsSE79TibRbdXwfvYMIt0Q=="
     },
     "@wiggly-games/data-structures": {
-      "version": "1.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/1.0.2/eac83b3847d125124b2ecb058f495f95b56529cc",
-      "integrity": "sha512-Gvd3PSo35Cn2en6SDtcAORN26J9+02GLl/aIiqavkEfGghRggwXyHiLdVZxyU4ujjkm6EESh9/0luA+wNofxow=="
+      "version": "2.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/2.0.3/460851249b369cdb65e3e0ac55613ba2996c82a2",
+      "integrity": "sha512-gcgobRIh8g5iSZB5sIVyLMqN24U3sgNBkaHrRPGAqnrEEwLpfILvdr/yxkgJmzyPIP553Q0p1hhnGBtKmPdL5w==",
+      "requires": {
+        "@wiggly-games/files": "^1.1.3",
+        "@wiggly-games/node-readline": "^1.0.1"
+      }
     },
     "@wiggly-games/files": {
-      "version": "1.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.0/980fe16b7d5b72af7f0754496fe92ec4216858da",
-      "integrity": "sha512-+AhroW0oV98vV4XLA+/U1FEAvueJ6ZoIVwQibKoG08oG4XmRNgyTwmWQePoR9zbQ9UTli3bkaxnp1ubCJVJ3gw=="
+      "version": "1.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.3/a4fdb1e872b660237a0bedff63c37824f132343c",
+      "integrity": "sha512-VuRJU7jX4E89FIK1ohOrkrzJCjizChyzWJn/EGej2DmcgT0REQvVUXCuGm3cQV7ydSV9KJQsLQBNzwz34n6hQg=="
     },
     "@wiggly-games/logs": {
       "version": "1.0.1",
@@ -1938,21 +1948,19 @@
       "integrity": "sha512-p6UGjAY2+3MU3MfEneRV26U1oEDpMExOZ3zzItSBYFSQDtp55HHxeKfWLvdGn/okfgsOH9XdbP3mh4DXGYOPtQ=="
     },
     "@wiggly-games/markov-chains": {
-      "version": "3.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/markov-chains/3.1.2/c0e805e1056a83e60d8053b4e9ffc2825020afa4",
-      "integrity": "sha512-QARqHASAb8ioCeQy2Xt4vAn1fUriE4IhVqil/ZOMOLhrz6ed5lAR/TwUpC7+WaXpFBADGpxS1T+GK5LyNT7yfg==",
+      "version": "5.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/markov-chains/5.0.0/b719e78c41c7e38e7e149b843569af220230207b",
+      "integrity": "sha512-+oiBxEaRMbSKISuz26zupC1HIUYvJzWF//tZ6jsoR9ZlwHzw7lUb5dMovm6+ITeOrT+9q/bavgFzveuFO3uSTw==",
       "requires": {
         "@wiggly-games/data-structures": "^2.0.0",
         "@wiggly-games/files": "^1.1.0",
         "msgpackr": "^1.10.2"
-      },
-      "dependencies": {
-        "@wiggly-games/data-structures": {
-          "version": "2.0.0",
-          "resolved": "https://npm.pkg.github.com/download/@wiggly-games/data-structures/2.0.0/4137d07440f6a4c54b9116bd328e225fd9105a27",
-          "integrity": "sha512-Sa9VpaFNDNO7xRsBMSnMVID4awLWTKTmNnBDzXNn9Uv42hKkDmaNDuivErvE69ObZW9pVSh/Pvv48soLm7ZN/Q=="
-        }
       }
+    },
+    "@wiggly-games/node-readline": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/node-readline/1.0.1/62837275964b51d28a85001eefcecd22e782e80a",
+      "integrity": "sha512-Vd7KWU0/SVwrGYDwEEjx7XU8mIRwqRO6yHBKmz5MLtrbjCj4FB9nDefbdJD1nAmZjORqrixGOhc8SijhRyNzJQ=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -2130,21 +2138,21 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
     },
     "discord-api-types": {
-      "version": "0.37.85",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.85.tgz",
-      "integrity": "sha512-T75aB9JEw9X0rlMChEMHbr9JlXMqdmdKiZVjBeKs91cJo28IuAIldj+VZoC+I+Q9gCaRjHlwRkcksy2XZY6c3A=="
+      "version": "0.37.90",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
+      "integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA=="
     },
     "discord.js": {
-      "version": "14.15.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.2.tgz",
-      "integrity": "sha512-wGD37YCaTUNprtpqMIRuNiswwsvSWXrHykBSm2SAosoTYut0VUDj9yo9t4iLtMKvuhI49zYkvKc2TNdzdvpJhg==",
+      "version": "14.15.3",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3.tgz",
+      "integrity": "sha512-/UJDQO10VuU6wQPglA4kz2bw2ngeeSbogiIPx/TsnctfzV/tNf+q+i1HlgtX1OGpeOBpJH9erZQNO5oRM2uAtQ==",
       "requires": {
-        "@discordjs/builders": "^1.8.1",
+        "@discordjs/builders": "^1.8.2",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.4.0",
         "@discordjs/rest": "^2.3.0",
         "@discordjs/util": "^1.1.0",
-        "@discordjs/ws": "^1.1.0",
+        "@discordjs/ws": "^1.1.1",
         "@sapphire/snowflake": "3.5.3",
         "discord-api-types": "0.37.83",
         "fast-deep-equal": "3.1.3",
@@ -2935,9 +2943,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "requires": {}
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,16 +18,17 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^20.12.12"
+    "@types/node": "^20.14.8"
   },
   "dependencies": {
-    "@wiggly-games/data-structures": "^1.0.2",
-    "@wiggly-games/files": "^1.0.5",
+    "@wiggly-games/data-structures": "^2.0.3",
+    "@wiggly-games/files": "^1.1.3",
     "@wiggly-games/logs": "^1.0.1",
-    "@wiggly-games/markov-chains": "^3.1.2",
+    "@wiggly-games/markov-chains": "^5.0.0",
+    "@wiggly-games/node-readline": "^1.0.1",
     "better-sqlite3": "^11.0.0",
-    "discord-api-types": "^0.37.85",
-    "discord.js": "^14.15.2",
+    "discord-api-types": "^0.37.90",
+    "discord.js": "^14.15.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "knex": "^3.1.0"

--- a/src/Discord/Commands/Generate.ts
+++ b/src/Discord/Commands/Generate.ts
@@ -13,6 +13,6 @@ module.exports = {
 		const dataset = await Database.GetDataSet(interaction.user.id);
 		const response = await Chains.get(dataset).Generate();
 		
-		await interaction.editReply(response);
+		await interaction.editReply(response.join(" "));
 	}
 }

--- a/src/Discord/Events/MessageHandler.ts
+++ b/src/Discord/Events/MessageHandler.ts
@@ -103,7 +103,7 @@ async function RespondToMessage(message: Message, extraText: string | undefined,
         // Generate a new message
         const dataSet = await Database.GetDataSet(message.author.id);
         const response = await Chains.get(dataSet).Generate();
-        messageToSend = response + " " + extraText;
+        messageToSend = response.join(" ") + " " + extraText;
     }
 
     // Respond to the message

--- a/src/Server/Server.ts
+++ b/src/Server/Server.ts
@@ -25,7 +25,7 @@ export async function Initialize({ Chains }) {
         }
 
         const path = filePaths[Math.floor(Math.random() * filePaths.length)];
-        res.send(await Chains.get(req.params.DataSet).Generate(path))
+        res.send((await Chains.get(req.params.DataSet).Generate(path)).join(" "))
     })
     app.listen(port, () => {
         console.log(`Example app listening on port ${port}`)

--- a/src/Types/TDependencyInjections.ts
+++ b/src/Types/TDependencyInjections.ts
@@ -3,5 +3,5 @@ import { MarkovChain } from "@wiggly-games/markov-chains";
 
 export type TDependencyInjections = {
     Database: IDatabase,
-    Chains: Map<string, MarkovChain>;
+    Chains: Map<string, MarkovChain<string>>;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,13 +24,13 @@ const ChainConfig : ChainConfiguration = {
 }
 
 // Creates the MarkovChains map, mapping from the DataSet name -> Chain.
-async function LoadChains(): Promise<Map<string, MarkovChain>> {
+async function LoadChains(): Promise<Map<string, MarkovChain<string>>> {
   const chainNames = await GetChainPaths();
-  const results = new Map<string, MarkovChain>();
+  const results = new Map<string, MarkovChain<string>>();
 
   for (const dataset of chainNames) {
-    const chain = new MarkovChain(GetDataSet(dataset), ChainConfig);
-    await chain.Load();
+    const chain = new MarkovChain<string>(GetDataSet(dataset), ChainConfig);
+    await chain.Load((x) => x);
 
     results.set(dataset, chain);
   }

--- a/src/train.ts
+++ b/src/train.ts
@@ -10,12 +10,28 @@ import { Paths, Initialize as InitializePaths, GetDataSet } from "./Helpers";
 
 const TRAINING_DATA = "./TrainingData";
 
+function buildWords(input: string[]): string[][] {
+    const trainingData: string[][] = [];
+
+    input.forEach(line => {
+        let sentences = line.replace(/([.?!])\s*(?=[A-Z])/g, "$1|").split(/[\|\n]/).map(x => x.trim()).filter(x => x !== "");
+        sentences.forEach(sentence => {
+            let words = sentence.split(" ").filter(x => x !== "");
+            trainingData.push(words);
+        });
+    });
+
+    return trainingData;
+}
+
 async function CreateTrainingSet(path: string, data: string[], settings: ChainConfiguration): Promise<string[]> {
     Files.CreateDirectory(path);
 
-    let chain = new MarkovChain(path, settings);
-    await chain.Train(data.join("\n"));
-    await chain.Save();
+    let chain = new MarkovChain<string>(path, settings);
+
+    const trainingSet = buildWords(data);
+    await chain.Train(trainingSet);
+    await chain.Save((x) => x);
 
     console.log(`Finished training ${path}`);
 


### PR DESCRIPTION
The MarkovChain package was updated to improve data persistence to:
- Use less size on disk
- Allow streaming data, instead of reading/writing the entire block of memory at once.

This in particular helps with running on the Raspberry Pis, which were getting overwhelmed by the size of the data when they'd try to train/generate. Should be able to cope with them better now.

It also modifies how the Chain works, previously the strings were being parsed by the chain, now it's moved over to where the strings are parsed by the bot instead. The Chain only takes lists of words and creates the transition matrices from them. Provides a better separation of concerns between the two.